### PR TITLE
NEW Validates no related article on captured ref deletion

### DIFF
--- a/resources/sql/articles.sql
+++ b/resources/sql/articles.sql
@@ -16,6 +16,9 @@ FROM articles a
 -- :name q-get-all-articles :? :*
 :snip:select
 
+-- :name q-get-article-for-captured-reference :? :1
+:snip:select WHERE id_captured_reference = :id
+
 -- :name count-articles :? :1
 -- :doc counts number of entries in articles table
 SELECT COUNT(*) FROM articles;

--- a/src/clj/kti/db/core.clj
+++ b/src/clj/kti/db/core.clj
@@ -28,6 +28,7 @@
 
 (conman/bind-connection *db* "sql/tags.sql")
 (conman/bind-connection *db* "sql/articles.sql")
+;; !!!! TODO -> Abstract this (how?)
 
 (defn get-article
   ([] (get-article {}))
@@ -40,6 +41,10 @@
   ([params] (q-get-all-articles (assoc params :select (snip-select-article))))
   ([db params & rest]
    (apply q-get-all-articles (assoc params :select (snip-select-article) rest))))
+
+(defn get-article-for-captured-reference [params]
+  (q-get-article-for-captured-reference
+   (assoc params :select (snip-select-article))))
 
 (conman/bind-connection *db* "sql/reviews.sql")
 

--- a/src/clj/kti/routes/services.clj
+++ b/src/clj/kti/routes/services.clj
@@ -2,7 +2,8 @@
   (:require [kti.routes.services.captured-references :refer :all]
             [kti.routes.services.articles
              :refer [get-all-articles get-article create-article! update-article!
-                     article-exists? delete-article!]]
+                     article-exists? delete-article!
+                     get-article-for-captured-reference]]
             [kti.routes.services.reviews
              :refer [create-review! get-review get-all-reviews update-review!
                      delete-review!]]
@@ -99,8 +100,13 @@
       (DELETE "/captured-references/:id" [id]
         :summary "Deletes a captured reference"
         (let-found? [captured-reference (get-captured-reference id)]
-          (delete-captured-reference! id)
-          (ok [])))
+          (let [validate-no-related-article (make-validate-no-related-article
+                                             get-article-for-captured-reference)
+                delete-captured-reference! (make-delete-captured-reference!
+                                            validate-no-related-article)]
+            (if-let [err (delete-captured-reference! id)]
+              (bad-request err)
+              (ok [])))))
 
       (GET "/articles" []
         :return       [Article]

--- a/src/clj/kti/routes/services/articles.clj
+++ b/src/clj/kti/routes/services/articles.clj
@@ -19,6 +19,7 @@
 (defn set-tags-to-article! [id tags]
   (doseq [t tags] (db/create-article-tag! {:article-id id :tag t})))
 
+;; !!!! TODO -> use kti.validate
 (defn validate-article [{:keys [id-captured-reference]}]
   (when (nil? (get-captured-reference id-captured-reference))
     (throw (ex-info (ARTICLE_ERR_INVALID_CAPTURED_REFERENCE_ID
@@ -34,6 +35,7 @@
 
 (defn create-article!
   [{:keys [tags id-captured-reference] :as data}]
+  ;; !!!! TODO -> Validate uniqueness of article for each captured reference
   (validate-article data)
     (with-db-transaction [t-conn *db*]
       (binding [*db* t-conn]
@@ -63,6 +65,7 @@
   [id]
   (-> {:id id} db/article-exists? (get :resp)))
 
+;; !!!! TODO -> use kti.validate
 (defn validate-tag [x]
   (cond
     (not (string? x))
@@ -90,6 +93,10 @@
 (defn get-article
   [id]
   (some-> (db/get-article {:id id}) parse-article-data))
+
+(defn get-article-for-captured-reference
+  [x]
+  (some-> (db/get-article-for-captured-reference x) parse-article-data))
 
 (defn parse-article-data [x]
   (-> x

--- a/src/clj/kti/routes/services/reviews.clj
+++ b/src/clj/kti/routes/services/reviews.clj
@@ -4,6 +4,7 @@
             [clojure.string :as str]))
 
 (def review-status #{:in-progress :completed :discarded})
+;; !!!! TODO -> use kti.validate
 (defn validate-review-status [x] (assert (review-status x)))
 (defn validate-id-article [x]
   (when-not (article-exists? x)

--- a/src/clj/kti/validation.clj
+++ b/src/clj/kti/validation.clj
@@ -1,0 +1,16 @@
+(ns kti.validation)
+
+(defn validate
+  "Runs all funs as validation functions.
+  Returns nil on validation success and {:error-message ...} on error.
+  Each fun must return nil on validation success or a string on error."
+  {:style/indent 1}
+  [arg & funs]
+  (loop [todo funs]
+    (if (nil? todo)
+      nil
+      (let [[f-head & f-tail] todo
+            result (f-head arg)]
+        (if (nil? result)
+          (recur f-tail)
+          {:error-msg result})))))

--- a/test/clj/kti/test/routes/services/articles_test.clj
+++ b/test/clj/kti/test/routes/services/articles_test.clj
@@ -35,6 +35,15 @@
       (is (= (get-article created-article-id)
              (assoc data :id created-article-id))))))
 
+(deftest test-get-article-for-captured-reference
+  (let [{:keys [id] :as captured-reference}
+        (get-captured-reference (create-test-captured-reference!))]
+    (is (nil? (get-article-for-captured-reference captured-reference)))
+    (let [article-id
+          (create-article! (get-article-data {:id-captured-reference id}))]
+      (is (= (get-article article-id)
+             (get-article-for-captured-reference captured-reference))))))
+
 (deftest test-update-article
   (let [captured-ref-id (create-test-captured-reference!)
         article-id (-> {:id-captured-reference captured-ref-id}

--- a/test/clj/kti/test/validation_test.clj
+++ b/test/clj/kti/test/validation_test.clj
@@ -1,0 +1,13 @@
+(ns kti.test.validation-test
+  (:require [clojure.test :refer :all]
+            [kti.validation :refer :all]))
+
+(deftest test-validate
+  (is (nil? (validate 1)))
+  (is (= {:error-msg "error"} (validate 1 (constantly "error"))))
+  (is (= nil (validate 1 (constantly nil))))
+  (is (= nil (validate 1 (constantly nil) (constantly nil))))
+  (is (= {:error-msg "foobar"} (validate 1
+                                 (constantly nil)
+                                 (constantly "foobar")
+                                 (constantly nil)))))


### PR DESCRIPTION
- Adds validation for DELETE on captured reference to avoid deleting a
  ref with an article.
- Adds `kti.validation` to help with validation cases