### PR TITLE
NEW Uses defrecord for KtiError

### DIFF
--- a/src/clj/kti/routes/services.clj
+++ b/src/clj/kti/routes/services.clj
@@ -9,6 +9,7 @@
             [kti.routes.services.reviews
              :refer [create-review! get-review get-all-reviews update-review!
                      delete-review!]]
+            [kti.validation :refer [kti-error?]]
             [ring.util.http-response :refer :all]
             [compojure.api.sweet :refer :all]
             [schema.core :as s]
@@ -122,11 +123,9 @@
         :body         [article-data ArticleInput]
         :summary      "POST for article"
         (let [res (create-article! article-data)]
-          (match [res]
-            [{:error-msg _}] (bad-request res)
-            [id] (created
-                  (str "/articles/" id)
-                  (get-article id)))))
+          (match [(kti-error? res) res]
+            [true  err] (bad-request err)
+            [false id]  (created (str "/articles/" id) (get-article id)))))
 
       (PUT "/articles/:id" [id]
         :return  Article

--- a/src/clj/kti/routes/services/articles.clj
+++ b/src/clj/kti/routes/services/articles.clj
@@ -82,6 +82,7 @@
 (defn create-tag!
   ([tag] (create-tag! *db* tag)) 
   ([db tag]
+   ;; !!!! TODO -> Use validation framework
    (when-let [err (validate-tag tag)]
      (throw (ex-info err {:type :tag-validation-exception})))
    (db/create-tag! db {:tag tag})))

--- a/src/clj/kti/routes/services/captured_references.clj
+++ b/src/clj/kti/routes/services/captured_references.clj
@@ -12,6 +12,7 @@
   (str  "Can not delete a captured reference used in an article."
         " Delete the article first."))
 
+;; !!!! TODO -> Validate min length for reference
 (defn create-captured-reference!
   ([x] (create-captured-reference! *db* x))
 
@@ -39,11 +40,11 @@
     DELETE-ERR-MSG-ARTICLE-EXISTS))
 
 (defn delete-captured-reference! [id]
-  (if-let [error (validate (get-captured-reference id) validate-no-related-article)]
-    error
-    (do
-      (db/delete-captured-reference! {:id id})
-      nil)))
+  (or
+   (validate (get-captured-reference id) validate-no-related-article)
+   (do
+     (db/delete-captured-reference! {:id id})
+     nil)))
 
 (def CAPTURED_REFERENCE_ID_ERR_NIL "Captured reference id can not be nil.")
 (def CAPTURED_REFERENCE_ID_ERR_NOT_FOUND

--- a/src/clj/kti/routes/services/reviews.clj
+++ b/src/clj/kti/routes/services/reviews.clj
@@ -13,6 +13,7 @@
 (def status->string (comp str/upper-case name))
 (def string->status (comp keyword str/lower-case))
 
+;; !!!! TODO -> use validation framework.
 (defn create-review!
   "Creates a review"
   [{:keys [status id-article] :as data}]
@@ -23,6 +24,7 @@
       db/create-review!
       (get (keyword "last_insert_rowid()"))))
 
+;; !!!! TODO -> use validation framework.
 (defn update-review!
   [id {:keys [status id-article] :as data}]
   (validate-id-article id-article)

--- a/src/clj/kti/validation.clj
+++ b/src/clj/kti/validation.clj
@@ -1,5 +1,7 @@
 (ns kti.validation)
 
+(defrecord KtiError [error-msg])
+
 (defn validate
   "Runs all funs as validation functions.
   Returns nil on validation success and {:error-message ...} on error.
@@ -13,4 +15,6 @@
             result (f-head arg)]
         (if (nil? result)
           (recur f-tail)
-          {:error-msg result})))))
+          (->KtiError result))))))
+
+(defn kti-error? [x] (instance? KtiError x))

--- a/test/clj/kti/test/routes/services/articles_test.clj
+++ b/test/clj/kti/test/routes/services/articles_test.clj
@@ -1,5 +1,6 @@
 (ns kti.test.routes.services.articles-test
   (:require [clojure.test :refer :all]
+            [kti.validation :refer (->KtiError)]
             [kti.utils :as utils]
             [kti.routes.services.articles :refer :all]
             [kti.routes.services.articles.base :refer :all]
@@ -56,7 +57,7 @@
 
     (testing "validates with validate-article-captured-reference-exists"
       (with-redefs [validate-article-captured-reference-exists (constantly "err")]
-        (is (= {:error-msg "err"} (update-article! article-id new-data)))))
+        (is (= (->KtiError "err") (update-article! article-id new-data)))))
 
     (testing "base"
       (is (nil? (update-article! article-id new-data)))
@@ -195,7 +196,7 @@
   (testing "Fails if captured-reference does not exists"
     (let [data (get-article-data {:id-captured-reference 293})]
       (assert (-> data :id-captured-reference get-captured-reference nil?))
-      (is (= {:error-msg (ARTICLE_ERR_INVALID_CAPTURED_REFERENCE_ID 293)}
+      (is (= (->KtiError (ARTICLE_ERR_INVALID_CAPTURED_REFERENCE_ID 293))
              (create-article! data))))))
 
 (deftest test-tag-exists?

--- a/test/clj/kti/test/validation_test.clj
+++ b/test/clj/kti/test/validation_test.clj
@@ -4,10 +4,10 @@
 
 (deftest test-validate
   (is (nil? (validate 1)))
-  (is (= {:error-msg "error"} (validate 1 (constantly "error"))))
+  (is (= (->KtiError "error") (validate 1 (constantly "error"))))
   (is (= nil (validate 1 (constantly nil))))
   (is (= nil (validate 1 (constantly nil) (constantly nil))))
-  (is (= {:error-msg "foobar"} (validate 1
+  (is (= (->KtiError "foobar") (validate 1
                                  (constantly nil)
                                  (constantly "foobar")
                                  (constantly nil)))))


### PR DESCRIPTION
- Creates KtiError record
- `validate` returns KtiError
- Patterns match on KtiError